### PR TITLE
Fix gutenberg download as of May 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,26 @@ Included files:
 - [LICENCE](LICENCE): Overview how files in this repository are licenced
 - [resources/](resources/): Data neccessary to run the examples and do the exercises.
 
-## Court order to block access from Project Gutenberg in Germany
-As of 3rd March 2018 access to Project Gutenberg is blocked from Germany
+## Copyright of material from project Gutenberg
+From 3rd March 2018 till October 2021, access to Project Gutenberg was blocked in Germany
 due to a court order, see the
-[official statement from PGLAF](https://cand.pglaf.org/germany/index.html)
-(the organisation hosting Project Gutenberg) for details.
-This implies as a user with a German IP address you will be unable to use the
-download script mentioned below.
-Unfortunately many of the exercises depend on the books from Project Gutenberg
-and whilst it is possible to do them without the proper book files,
-the results might deviate.
-I am currently unaware of a good alternative to obtain the Project Gutenberg
-books in a simple way and I am unsure about the
-legal status regards hosting them myself.
-In the lack of time on my side the excercises will stay broken for now,
-which I very much regret.
+[official statement from PGLAF](https://cand.pglaf.org/germany/index.html). 
+As similar situations might occur in the future,
+It is up to you to verify the books used in this course are in the public domain. The following books are used:
+- Dracula by Bram Stoker
+- The Adventures of Tom Sawyer by Mark Twain
+- Adventures of Huckleberry Finn by Mark Twain
+- The Prince by Nicolo Machiavelli
+- Leaves of Grass by Walt Whitman
+- Emma by Jane Austen
+- Sense and Sensibility by Jane Austen
+- The Picture of Dorian Gray by Oscar Wilde
+- The Yellow Wallpaper by Charlotte Perkins Gilman
+- Grimms’ Fairy Tales by Jacob Grimm and Wilhelm Grimm
+- Metamorphosis by Franz Kafka
+- The Importance of Being Earnest -- A Trivial Comedy for Serious People by Oscar Wilde
+- The Divine Comedy -- The Vision of Hell, Purgatory and Paradise by Dante Alighieri
+- A Tale of Two Cities -- A Story of the French Revolution by Charles Dickens
 
 ## Setup
 Before being able to do the Project Gutenberg-related exercises, you should

--- a/resources/gutenberg/download.sh
+++ b/resources/gutenberg/download.sh
@@ -3,15 +3,35 @@
 
 LIST="345 74 76 1232 1322 158 161 174 1952 2591 5200 844 8800 98"
 
+# Optionally verify these books are in the public domain in your country of residence
+# 345 - Dracula by Bram Stoker
+# 74 - The Adventures of Tom Sawyer by Mark Twain
+# 76 - Adventures of Huckleberry Finn by Mark Twain
+# 1232 - The Prince by Nicolo Machiavelli
+# 1322 - Leaves of Grass by Walt Whitman
+# 158 - Emma by Jane Austen
+# 161 - Sense and Sensibility by Jane Austen
+# 174 - The Picture of Dorian Gray by Oscar Wilde
+# 1952 - The Yellow Wallpaper by Charlotte Perkins Gilman
+# 2591 - Grimms’ Fairy Tales by Jacob Grimm and Wilhelm Grimm
+# 5200 - Metamorphosis by Franz Kafka
+# 844 - The Importance of Being Earnest -- A Trivial Comedy for Serious People by Oscar Wilde
+# 8800 - The Divine Comedy -- The Vision of Hell, Purgatory and Paradise by Dante Alighieri
+# 98 - A Tale of Two Cities -- A Story of the French Revolution by Charles Dickens
+
+# select a mirror from https://www.gutenberg.org/MIRRORS.ALL
+# as requested in https://www.gutenberg.org/policy/terms_of_use.html
+MIRROR=http://www.mirrorservice.org/sites/ftp.ibiblio.org/pub/docs/books/gutenberg/
+
 #----
 
 return_url() {
 	#$1: id
-	local URL="http://www.gutenberg.lib.md.us"
+	local URL=$MIRROR
 	for ((i=0;i<${#1}-1;++i)) {
 		URL="$URL/${1:$i:1}"
 	}
-	echo "$URL/$1/$1.txt"
+	echo "$URL/$1/$1-0.txt"
 }
 
 verbose_sleep() {


### PR DESCRIPTION
Thanks for providing the course material online! This PR fixes the download script. Also, it seems the legal issues in Germany have been resolved, and the course doesn't use any books from the 3 authors which are still banned in Germany according to https://cand.pglaf.org/germany/index.html:

    Heinrich Mann, who died in 1950.
    Thomas Mann, who died in 1955.
    Alfred Döblin, who died in 1957.
 